### PR TITLE
Updates and more

### DIFF
--- a/0005-appdata-Add-OARS-info.patch
+++ b/0005-appdata-Add-OARS-info.patch
@@ -1,0 +1,34 @@
+From 8bd14f37bf09f3342e11d1a905c65610a6a3bccb Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <mathieu@hashbang.fr>
+Date: Wed, 8 Jan 2020 14:26:15 +0100
+Subject: [PATCH 5/8] appdata: Add OARS info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Open Age Ratings Service allows free and commercial software to
+generate the OARS XML required for the AppData file. OARS relies on
+honest answers from upstream projects and is purely informational.
+
+Adding this to the appdata allows software centers (e.g GNOME Software,
+KDE Discover, …) to provide filters for users, for example to implement
+parental control.
+---
+ share/appdata/ch.x29a.playitslowly.appdata.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/share/appdata/ch.x29a.playitslowly.appdata.xml b/share/appdata/ch.x29a.playitslowly.appdata.xml
+index 0b754f0..3728f14 100644
+--- a/share/appdata/ch.x29a.playitslowly.appdata.xml
++++ b/share/appdata/ch.x29a.playitslowly.appdata.xml
+@@ -9,6 +9,7 @@
+     </p>
+   </description>
+   <url type="homepage">https://29a.ch/playitslowly/</url>
++  <content_rating type="oars-1.1" />
+   <screenshots>
+     <screenshot type="default">https://29a.ch/playitslowly/screenshot.png</screenshot>
+   </screenshots>
+-- 
+2.24.1
+

--- a/0006-appdata-Follow-the-new-recommendation-for-app-ids.patch
+++ b/0006-appdata-Follow-the-new-recommendation-for-app-ids.patch
@@ -1,0 +1,30 @@
+From 6cd346d0547f790c03cf916ac67b713db3c971c7 Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <mathieu@hashbang.fr>
+Date: Wed, 8 Jan 2020 14:29:08 +0100
+Subject: [PATCH 6/8] appdata: Follow the new recommendation for app ids
+
+It used to be that app ids were expected to contain the ".desktop" file
+extension.
+
+These days, we prefer not including it in the id, but adding the
+"launchable" tag to link the app to its desktop launcher.
+---
+ share/appdata/ch.x29a.playitslowly.appdata.xml | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/share/appdata/ch.x29a.playitslowly.appdata.xml b/share/appdata/ch.x29a.playitslowly.appdata.xml
+index 3728f14..7d777c0 100644
+--- a/share/appdata/ch.x29a.playitslowly.appdata.xml
++++ b/share/appdata/ch.x29a.playitslowly.appdata.xml
+@@ -1,6 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <application>
+-  <id type="desktop">ch.x29a.playitslowly.desktop</id>
++  <id type="desktop">ch.x29a.playitslowly</id>
++  <launchable type="desktop-id">ch.x29a.playitslowly.desktop</launchable>
+   <name>Play it Slowly</name>
+   <summary>Play music at a different speed</summary>
+   <description>
+-- 
+2.24.1
+

--- a/0007-appdata-Add-a-reference-to-the-old-app-id.patch
+++ b/0007-appdata-Add-a-reference-to-the-old-app-id.patch
@@ -1,0 +1,37 @@
+From e8b3a409a61d6f907b37e673a1f901f336299dc5 Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <mathieu@hashbang.fr>
+Date: Wed, 8 Jan 2020 14:40:06 +0100
+Subject: [PATCH 7/8] appdata: Add a reference to the old app id
+
+Software centers like GNOME Software allow users to write app reviews.
+
+PlayItSlowly had such reviews associated with its old app id:
+
+https://odrs.gnome.org/1.0/reviews/api/app/playitslowly.desktop
+
+Unfortunately, they are invisible with the new app id.
+
+This commit will let software centers know they should "merge" the
+reviews, so that the ones linked to the old app id are visible with the
+new app id.
+---
+ share/appdata/ch.x29a.playitslowly.appdata.xml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/share/appdata/ch.x29a.playitslowly.appdata.xml b/share/appdata/ch.x29a.playitslowly.appdata.xml
+index 7d777c0..abb11e7 100644
+--- a/share/appdata/ch.x29a.playitslowly.appdata.xml
++++ b/share/appdata/ch.x29a.playitslowly.appdata.xml
+@@ -2,6 +2,9 @@
+ <application>
+   <id type="desktop">ch.x29a.playitslowly</id>
+   <launchable type="desktop-id">ch.x29a.playitslowly.desktop</launchable>
++  <provides>
++    <id>playitslowly.desktop</id>
++  </provides>
+   <name>Play it Slowly</name>
+   <summary>Play music at a different speed</summary>
+   <description>
+-- 
+2.24.1
+

--- a/0008-appdata-Add-release-descriptions.patch
+++ b/0008-appdata-Add-release-descriptions.patch
@@ -1,0 +1,51 @@
+From 359cded252acd12f576f2245910293a63aa5f210 Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <mathieu@hashbang.fr>
+Date: Wed, 8 Jan 2020 15:29:58 +0100
+Subject: [PATCH 8/8] appdata: Add release descriptions
+
+This allows software centers like GNOME Software or KDE Discover to
+display what's new when users update the app.
+
+In addition, it also lets them display the version to the users.
+---
+ .../appdata/ch.x29a.playitslowly.appdata.xml  | 26 +++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/share/appdata/ch.x29a.playitslowly.appdata.xml b/share/appdata/ch.x29a.playitslowly.appdata.xml
+index abb11e7..28ec42b 100644
+--- a/share/appdata/ch.x29a.playitslowly.appdata.xml
++++ b/share/appdata/ch.x29a.playitslowly.appdata.xml
+@@ -19,4 +19,30 @@
+   </screenshots>
+   <project_license>GPL-3.0+</project_license>
+   <metadata_license>CC0-1.0</metadata_license>
++  <releases>
++    <release version="1.5.1" date="2016-05-21">
++      <description>
++        <p>This is a bug fix release:</p>
++        <ul>
++          <li>Fixed config loading</li>
++        </ul>
++      </description>
++    </release>
++    <release version="1.5.0" date="2016-05-21">
++      <description>
++        <p>This is a major release:</p>
++        <ul>
++          <li>Updated to Python3, GTK3 and GStreamer 1.0</li>
++          <li>Minor design cleanup</li>
++          <li>Fixed a bug where the file chooser would not show the currently selected file</li>
++        </ul>
++      </description>
++    </release>
++    <release version="1.4.0" date="2011-07-03" />
++    <release version="1.3.1" date="2010-12-08" />
++    <release version="1.3.0" date="2010-07-04" />
++    <release version="1.2.0" date="2009-05-23" />
++    <release version="1.1.0" date="2009-01-08" />
++    <release version="1.0.0" date="2008-12-11" />
++  </releases>
+ </application>
+-- 
+2.24.1
+

--- a/ch.x29a.playitslowly.json
+++ b/ch.x29a.playitslowly.json
@@ -8,11 +8,7 @@
         "--share=ipc",
         "--socket=pulseaudio",
         "--socket=x11",
-        "--filesystem=home:ro",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--filesystem=home:ro"
     ],
     "modules": [
         {

--- a/ch.x29a.playitslowly.json
+++ b/ch.x29a.playitslowly.json
@@ -1,7 +1,7 @@
 {
     "id": "ch.x29a.playitslowly",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.30",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "playitslowly",
     "finish-args": [
@@ -24,7 +24,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.com/soundtouch/soundtouch.git",
-                    "commit": "7f594f8b7d10bbc16a4a31de8ec5a279af9c7378"
+                    "tag": "2.1.2",
+                    "commit": "9205fc971ed23cff407a67242bb9036a51113af4"
                 }
             ],
             "cleanup": [
@@ -37,20 +38,6 @@
         },
         {
             "name": "gstreamer-plugins-bad",
-            "build-options" : {
-                "arch" : {
-                    "i386" : {
-                        "config-opts" : [
-                            "--build=i586-unknown-linux-gnu"
-                        ]
-                    },
-                    "arm" : {
-                        "config-opts" : [
-                            "--build=arm-unknown-linux-gnueabi"
-                        ]
-                    }
-                }
-            },
             "config-opts": [
                 "--disable-bz2",
                 "--disable-curl",
@@ -82,8 +69,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.14.4.tar.xz",
-                    "sha256": "910b4e0e2e897e8b6d06767af1779d70057c309f67292f485ff988d087aa0de5"
+                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.16.1.tar.xz",
+                    "sha256": "56481c95339b8985af13bac19b18bc8da7118c2a7d9440ed70e7dcd799c2adb5"
                 }
             ],
             "cleanup": [

--- a/ch.x29a.playitslowly.json
+++ b/ch.x29a.playitslowly.json
@@ -106,6 +106,22 @@
                 {
                     "type": "patch",
                     "path": "0004-Rename-the-desktop-appdata-and-icon-files.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0005-appdata-Add-OARS-info.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0006-appdata-Follow-the-new-recommendation-for-app-ids.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0007-appdata-Add-a-reference-to-the-old-app-id.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0008-appdata-Add-release-descriptions.patch"
                 }
             ]
         }


### PR DESCRIPTION
This changes a few things:

* move to the GNOME 3.34 runtime;
* remove the DConf access;
* add OARS;
* provide the old app id (to get all the reviews)
* add release descriptions

Fixes #1 