### PR TITLE
Upgrade to GNOME 3.38 runtime

### DIFF
--- a/ch.x29a.playitslowly.json
+++ b/ch.x29a.playitslowly.json
@@ -1,7 +1,7 @@
 {
     "id": "ch.x29a.playitslowly",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.36",
     "sdk": "org.gnome.Sdk",
     "command": "playitslowly",
     "finish-args": [
@@ -18,10 +18,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.com/soundtouch/soundtouch.git",
-                    "tag": "2.1.2",
-                    "commit": "9205fc971ed23cff407a67242bb9036a51113af4"
+                    "type": "archive",
+                    "url": "https://gitlab.com/soundtouch/soundtouch/-/archive/2.1.2/soundtouch-2.1.2.tar.gz",
+                    "sha256": "2826049e2f34efbc4c8a47d00c93649822b0c14e1f29f5569835704814590732"
                 }
             ],
             "cleanup": [

--- a/ch.x29a.playitslowly.json
+++ b/ch.x29a.playitslowly.json
@@ -1,7 +1,7 @@
 {
     "id": "ch.x29a.playitslowly",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "playitslowly",
     "finish-args": [
@@ -33,39 +33,35 @@
         },
         {
             "name": "gstreamer-plugins-bad",
+            "buildsystem": "meson",
             "config-opts": [
-                "--disable-bz2",
-                "--disable-curl",
-                "--disable-dash",
-                "--disable-decklink",
-                "--disable-dtls",
-                "--disable-dvb",
-                "--disable-examples",
-                "--disable-fbdev",
-                "--disable-gl",
-                "--disable-gtk3",
-                "--disable-gtk-doc",
-                "--disable-hls",
-                "--disable-introspection",
-                "--disable-kms",
-                "--disable-openal",
-                "--disable-rsvg",
-                "--disable-shm",
-                "--disable-smoothstreaming",
-                "--disable-sndfile",
-                "--disable-vcd",
-                "--disable-vdpau",
-                "--disable-vulkan",
-                "--disable-wayland",
-                "--disable-webp",
-                "--enable-orc",
-                "--with-plugins=soundtouch"
+                "-Dbz2=disabled",
+                "-Dcurl=disabled",
+                "-Ddash=disabled",
+                "-Ddecklink=disabled",
+                "-Ddtls=disabled",
+                "-Ddvb=disabled",
+                "-Dexamples=disabled",
+                "-Dfbdev=disabled",
+                "-Dgl=disabled",
+                "-Dhls=disabled",
+                "-Dintrospection=disabled",
+                "-Dkms=disabled",
+                "-Dopenal=disabled",
+                "-Drsvg=disabled",
+                "-Dsmoothstreaming=disabled",
+                "-Dsndfile=disabled",
+                "-Dvulkan=disabled",
+                "-Dwayland=disabled",
+                "-Dwebp=disabled",
+                "-Dorc=disabled",
+                "-Dsoundtouch=enabled"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.16.1.tar.xz",
-                    "sha256": "56481c95339b8985af13bac19b18bc8da7118c2a7d9440ed70e7dcd799c2adb5"
+                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.16.2.tar.xz",
+                    "sha256": "f1cb7aa2389569a5343661aae473f0a940a90b872001824bc47fa8072a041e74"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Hey, I did not want to install the GNOME 3.34 runtime so I decided to build the flatpak and share it here.

I did a quick try with 3.38 also, but I got some errors when building gst-plugins-bad version 1.16.
I tried building version 1.18 (released few days ago), but the Sdk still has gstreamer 1.16 so I cannot compile it. I guess I should wait until gstreamer 1.18 enters the Sdk.
